### PR TITLE
Add instrumentation for test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### Added
+
+- nyc instrumentation to measure test coverage
+
 ### [1.0.0] - 2025-01-09
 
 - initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- nyc instrumentation to measure test coverage
+- instrumentation to measure test coverage
 
 ### [1.0.0] - 2025-01-09
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ exports.load_template_ini = function () {
       ],
     },
     () => {
+      // This closure is run a few seconds after template.ini changes
+      // Re-run the outer function again
       this.load_template_ini()
     },
   )

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
   },
-  "nyc": {
+  "c8": {
     "all": true,
     "include": [
       "index.js"

--- a/package.json
+++ b/package.json
@@ -17,25 +17,9 @@
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
     "test": "node --test",
-    "test:coverage": "c8 npm test",
+    "test:coverage": "npx c8 npm test",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
-  },
-  "c8": {
-    "all": true,
-    "include": [
-      "index.js"
-    ],
-    "exclude": [
-      "test/**",
-      "node_modules/**"
-    ],
-    "reporter": [
-      "text",
-      "text-summary",
-      "html",
-      "lcov"
-    ]
   },
   "repository": {
     "type": "git",
@@ -53,8 +37,7 @@
   "homepage": "https://github.com/haraka/haraka-plugin-template#readme",
   "devDependencies": {
     "@haraka/eslint-config": "^2.0.2",
-    "haraka-test-fixtures": "^1.3.8",
-    "c8": "^10.1.3"
+    "haraka-test-fixtures": "^1.3.8"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "CHANGELOG.md",
     "config"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "format": "npm run prettier:fix && npm run lint:fix",
     "lint": "npx eslint *.js test",
@@ -14,8 +17,25 @@
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
     "test": "node --test",
+    "test:coverage": "nyc npm test",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
+  },
+  "nyc": {
+    "all": true,
+    "include": [
+      "index.js"
+    ],
+    "exclude": [
+      "test/**",
+      "node_modules/**"
+    ],
+    "reporter": [
+      "text",
+      "text-summary",
+      "html",
+      "lcov"
+    ]
   },
   "repository": {
     "type": "git",
@@ -33,7 +53,8 @@
   "homepage": "https://github.com/haraka/haraka-plugin-template#readme",
   "devDependencies": {
     "@haraka/eslint-config": "^2.0.2",
-    "haraka-test-fixtures": "^1.3.8"
+    "haraka-test-fixtures": "^1.3.8",
+    "nyc": "^17.1.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
     "test": "node --test",
-    "test:coverage": "nyc npm test",
+    "test:coverage": "c8 npm test",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
   },
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@haraka/eslint-config": "^2.0.2",
     "haraka-test-fixtures": "^1.3.8",
-    "nyc": "^17.1.0"
+    "c8": "^10.1.3"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-template",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Haraka plugin that...CHANGE THIS",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
     "test": "node --test",
-    "test:coverage": "npx c8 npm test",
+    "test:coverage": "HARAKA_COVERAGE=1 npx c8 npm test",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,43 +1,71 @@
 const assert = require('node:assert/strict')
+const path = require('node:path')
 const { beforeEach, describe, it } = require('node:test')
 
 // npm modules
 const fixtures = require('haraka-test-fixtures')
+const plugin_module = require('../index.js')
 
 // start of tests
 //    assert: https://nodejs.org/api/assert.html
 
+let plugin
+let connection
+
 beforeEach(() => {
-  this.plugin = new fixtures.plugin('template')
+  plugin = new fixtures.plugin('template')
+  
+  Object.assign(plugin, plugin_module)
 })
 
-describe('template', () => {
-  it('loads', () => {
-    assert.ok(this.plugin)
+describe('register', () => {
+  it('has a register function', () => {
+    assert.equal('function', typeof plugin.register)
+  })
+
+  it('registers', () => {
+    const expected_cfg = {
+      main: {
+        disabled: false,
+        enabled: true,
+      },
+      feature_section: {
+        yes: true
+      }
+    }
+
+    assert.deepEqual(plugin.cfg, undefined)
+    plugin.register()
+    assert.deepEqual(plugin.cfg, expected_cfg)
   })
 })
 
 describe('load_template_ini', () => {
+  it('loads', () => {
+    assert.equal('object', typeof plugin)
+    assert.equal('template', plugin.name)
+  })
+
   it('loads template.ini from config/template.ini', () => {
-    this.plugin.load_template_ini()
-    assert.ok(this.plugin.cfg)
+    plugin.load_template_ini()
+    assert.ok(plugin.cfg)
   })
 
   it('initializes enabled boolean', () => {
-    this.plugin.load_template_ini()
-    assert.equal(this.plugin.cfg.main.enabled, true, this.plugin.cfg)
+    plugin.load_template_ini()
+    assert.equal(plugin.cfg.main.enabled, true, plugin.cfg)
   })
 })
 
 describe('uses text fixtures', () => {
   it('sets up a connection', () => {
-    this.connection = fixtures.connection.createConnection({})
-    assert.ok(this.connection.server)
+    connection = fixtures.connection.createConnection({})
+    assert.ok(connection.server)
   })
 
   it('sets up a transaction', () => {
-    this.connection = fixtures.connection.createConnection({})
-    this.connection.init_transaction()
-    assert.ok(this.connection.transaction.header)
+    connection = fixtures.connection.createConnection({})
+    connection.init_transaction()
+    assert.ok(connection.transaction.header)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 const assert = require('node:assert/strict')
-const path = require('node:path')
 const { beforeEach, describe, it } = require('node:test')
 
 // npm modules

--- a/test/index.js
+++ b/test/index.js
@@ -8,18 +8,15 @@ const plugin_module = require('../index.js')
 // start of tests
 //    assert: https://nodejs.org/api/assert.html
 
-let plugin
-let connection
-
 beforeEach(() => {
-  plugin = new fixtures.plugin('template')
+  this.plugin = new fixtures.plugin('template')
   
-  Object.assign(plugin, plugin_module)
+  Object.assign(this.plugin, plugin_module)
 })
 
 describe('register', () => {
   it('has a register function', () => {
-    assert.equal('function', typeof plugin.register)
+    assert.equal('function', typeof this.plugin.register)
   })
 
   it('registers', () => {
@@ -33,38 +30,38 @@ describe('register', () => {
       }
     }
 
-    assert.deepEqual(plugin.cfg, undefined)
-    plugin.register()
-    assert.deepEqual(plugin.cfg, expected_cfg)
+    assert.deepEqual(this.plugin.cfg, undefined)
+    this.plugin.register()
+    assert.deepEqual(this.plugin.cfg, expected_cfg)
   })
 })
 
 describe('load_template_ini', () => {
   it('loads', () => {
-    assert.equal('object', typeof plugin)
-    assert.equal('template', plugin.name)
+    assert.equal('object', typeof this.plugin)
+    assert.equal('template', this.plugin.name)
   })
 
   it('loads template.ini from config/template.ini', () => {
-    plugin.load_template_ini()
-    assert.ok(plugin.cfg)
+    this.plugin.load_template_ini()
+    assert.ok(this.plugin.cfg)
   })
 
   it('initializes enabled boolean', () => {
-    plugin.load_template_ini()
-    assert.equal(plugin.cfg.main.enabled, true, plugin.cfg)
+    this.plugin.load_template_ini()
+    assert.equal(this.plugin.cfg.main.enabled, true, this.plugin.cfg)
   })
 })
 
 describe('uses text fixtures', () => {
-  it('sets up a connection', () => {
-    connection = fixtures.connection.createConnection({})
-    assert.ok(connection.server)
+  it('sets up a this.connection', () => {
+    this.connection = fixtures.connection.createConnection({})
+    assert.ok(this.connection.server)
   })
 
   it('sets up a transaction', () => {
-    connection = fixtures.connection.createConnection({})
-    connection.init_transaction()
-    assert.ok(connection.transaction.header)
+    this.connection = fixtures.connection.createConnection({})
+    this.connection.init_transaction()
+    assert.ok(this.connection.transaction.header)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,11 @@ const plugin_module = require('../index.js')
 beforeEach(() => {
   this.plugin = new fixtures.plugin('template')
   
-  Object.assign(this.plugin, plugin_module)
+  // Conditionally inject for coverage tracking
+  if (process.env.HARAKA_COVERAGE) {
+    const plugin_module = require('../index.js')
+    Object.assign(this.plugin, plugin_module)
+  }
 })
 
 describe('register', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ const fixtures = require('haraka-test-fixtures')
 beforeEach(() => {
   this.plugin = new fixtures.plugin('template')
   
-  // Conditionally inject for coverage tracking
+  // replace vm-compiled fns with instrumented copies for coverage tracking
   if (process.env.HARAKA_COVERAGE) {
     const plugin_module = require('../index.js')
     Object.assign(this.plugin, plugin_module)

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@ const { beforeEach, describe, it } = require('node:test')
 
 // npm modules
 const fixtures = require('haraka-test-fixtures')
-const plugin_module = require('../index.js')
 
 // start of tests
 //    assert: https://nodejs.org/api/assert.html
@@ -58,7 +57,7 @@ describe('load_template_ini', () => {
 })
 
 describe('uses text fixtures', () => {
-  it('sets up a this.connection', () => {
+  it('sets up a connection', () => {
     this.connection = fixtures.connection.createConnection({})
     assert.ok(this.connection.server)
   })


### PR DESCRIPTION
Changes proposed in this pull request:
- added node v22 requirement
- refactored tests to use local plugin instead of this.plugin
- added comments to clarify how the config.get closure works
- added nyc instrumentation for test coverage

Checklist:

- [ ] docs updated
- [X] tests updated
- [X] Changes.md updated
- [X] package.json.version bumped
